### PR TITLE
Fix pagination

### DIFF
--- a/get-repos
+++ b/get-repos
@@ -29,7 +29,7 @@ fetch_api() {
 fetch_all_pages() {
   header_file="$(mktemp)"
   curl --dump-header "$header_file" --silent --user "$(cat ~/.github-creds)" -- "$1" 
-  next_page="$(sed -ne 's/^Link:.*<\([^>]*\)>; rel="next".*/\1/p' "$header_file")"
+  next_page="$(sed -ne 's/^Link:.*<\([^>]*\)>; rel="next".*/\1/ip' "$header_file")"
   rm -f -- "$header_file"
 
   if [[ -n "$next_page" ]]; then


### PR DESCRIPTION
Github changed their "link:" header to be lower-case, which broke the previous, case sensitive logic here.