### PR TITLE
Fix site generation

### DIFF
--- a/Dockerfile.get-repos
+++ b/Dockerfile.get-repos
@@ -4,4 +4,5 @@ RUN apt-get update && apt-get install -y --force-yes curl git jq
 COPY get-repos /opt/
 
 VOLUME /opt/repos
-CMD /opt/get-repos /opt/repos
+WORKDIR /opt
+CMD ./get-repos ./repos

--- a/build-site
+++ b/build-site
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
- 
+
 build_repo() {
   if [[ -f "$1/.nojekyll" ]]; then
     publish_dir "$1/" "$2"

--- a/get-repos
+++ b/get-repos
@@ -61,8 +61,8 @@ repo_dir="$1"
 mkdir -p "$repo_dir"
 
 fetch_all_pages "https://api.github.com/user/repos?type=owner" |
-  jq -r '.[] | ([.name, .branches_url, .git_url] | join(" "))' |
-  while read -r name branches_url git_url rest; do
+  jq -r '.[] | ([.name, .branches_url, .clone_url] | join(" "))' |
+  while read -r name branches_url clone_url rest; do
     if [[ -n "$quick" && -f "$repo_dir/.$name" ]]; then
       continue
     fi
@@ -79,7 +79,7 @@ fetch_all_pages "https://api.github.com/user/repos?type=owner" |
         jq -r '.[].name' |
         grep -q "^$branch\$"; then
         rm -f "$repo_dir/.$name"
-        clone_repo "$git_url"
+        clone_repo "$clone_url"
       else
         :> "$repo_dir/.$name"
       fi

--- a/get-repos
+++ b/get-repos
@@ -61,8 +61,8 @@ repo_dir="$1"
 mkdir -p "$repo_dir"
 
 fetch_all_pages "https://api.github.com/user/repos?type=owner" |
-  jq -r '.[] | ([.name, .branches_url, .clone_url] | join(" "))' |
-  while read -r name branches_url clone_url rest; do
+  jq -r '.[] | ([.name, .branches_url, .clone_url, .default_branch] | join(" "))' |
+  while read -r name branches_url clone_url default_branch rest; do
     if [[ -n "$quick" && -f "$repo_dir/.$name" ]]; then
       continue
     fi
@@ -70,7 +70,7 @@ fetch_all_pages "https://api.github.com/user/repos?type=owner" |
     branch="gh-pages"
     case "$name" in
       *.github.io)
-        branch="master"
+        branch="$default_branch"
     esac
 
     if [[ ! -d "$repo_dir/$name" ]]; then

--- a/get-repos
+++ b/get-repos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -23,12 +23,12 @@ switch_to_branch() {
 }
 
 fetch_api() {
-  curl --silent --user "$(cat ~/.github-creds)" -- "$1" 
+  curl --silent --user "$(cat ~/.github-creds)" -- "$1"
 }
 
 fetch_all_pages() {
   header_file="$(mktemp)"
-  curl --dump-header "$header_file" --silent --user "$(cat ~/.github-creds)" -- "$1" 
+  curl --dump-header "$header_file" --silent --user "$(cat ~/.github-creds)" -- "$1"
   next_page="$(sed -ne 's/^Link:.*<\([^>]*\)>; rel="next".*/\1/ip' "$header_file")"
   rm -f -- "$header_file"
 
@@ -41,7 +41,8 @@ quick=
 
 while getopts q opt; do
   case "$opt" in
-    q) quick=1
+    q) quick=1 ;;
+    *) echo "bad option: $opt" >&2; exit 1
   esac
 done
 shift $(( OPTIND - 1 ))

--- a/get-repos.docker
+++ b/get-repos.docker
@@ -2,4 +2,8 @@
 
 docker build --file Dockerfile.get-repos --tag jekyll-pages/get-repos . >&2
 
-(cd ~ && tar c .github-creds) | docker run --interactive --rm --volume "$(readlink --canonicalize -- "$1"):/opt/repos" jekyll-pages/get-repos /bin/sh -c "cd ~; tar x; cd /opt; ./get-repos $1"
+docker run \
+  --rm \
+  --volume "$HOME/.github-creds:/root/.github-creds" \
+  --volume "$(readlink --canonicalize -- "$1"):/opt/repos" \
+  jekyll-pages/get-repos

--- a/get-repos.docker
+++ b/get-repos.docker
@@ -4,6 +4,7 @@ docker build --file Dockerfile.get-repos --tag jekyll-pages/get-repos . >&2
 
 docker run \
   --rm \
-  --volume "$HOME/.github-creds:/root/.github-creds" \
+  --user "$UID:$GID" \
+  --volume "$HOME/.github-creds:/.github-creds" \
   --volume "$(readlink --canonicalize -- "$1"):/opt/repos" \
   jekyll-pages/get-repos

--- a/get-repos.docker
+++ b/get-repos.docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker build --file Dockerfile.get-repos --tag jekyll-pages/get-repos . >&2
 

--- a/publish
+++ b/publish
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
**Potential breaking change**: `./get-repos.docker` now creates `repos` dir contents under ownership of the current UID

It was an oversight that it was created under `root` ownership originally. By making the current user the owner it makes it easier to work with the files outside of the prescribed Docker container. This may break if you are running jekyll-pages under the `root` user or any UID that has a non-`/` homedir specified in the Docker container.

Given how jekyll-pages was in a largely broken state, I'm assuming there aren't too many users. But if this causes an issue, there are ways we can make it better.